### PR TITLE
feat(operation): 消息类型更贴合官方接口

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ derive_builder = "0.20.2"
 reqwest-eventsource = "0.6.0"
 thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = "1.0.140"
+serde_json = "1.0.141"
 tracing = "0.1.41"
 bytes = "1.10.1"
 reqwest = { version = "0.12.22", features = [
@@ -26,7 +26,7 @@ reqwest = { version = "0.12.22", features = [
 ], default-features = false }
 secrecy = { version = "0.10.3", features = ["serde"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
-tokio = { version = "1.46.1", features = ["full"] }
+tokio = { version = "1.47.0", features = ["full"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.15", features = ["codec", "io-util"] }
 async-stream = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-dashscope"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "A Rust client for DashScope API"
 repository = "https://github.com/kingzcheung/async-dashscope"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **多模态生成**：支持图像、音频等多种模态的数据生成任务。
 - **Embedding**：提供文本 embedding 功能，用于将文本转换为向量表示，便于后续的语义分析和相似度计算。
 - **DeepSeek**:  支持百炼平台的 deepseek 模型的调用
+- **Kimi**: 支持 Moonshot-Kimi-K2-Instruct
 - **深度思考**: 支持 qwen/deepseek 深度思考
 - **工具调用**: 支持qwen 系列的工具调用(deepseek 不支持)
 - **音频合成**： 支持 qwen-tts 音频合成

--- a/examples/deepseek-r1.rs
+++ b/examples/deepseek-r1.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .parameters(
             ParametersBuilder::default()
                 .result_format("message")
+                .enable_thinking(true)
                 .build()?,
         )
         .build()?;

--- a/examples/roles.rs
+++ b/examples/roles.rs
@@ -1,7 +1,7 @@
 use async_dashscope::{
     operation::{
         common::ParametersBuilder,
-        generation::{GenerationParamBuilder, InputBuilder, MessageBuilder},
+        generation::{GenerationParamBuilder, InputBuilder, MessageBuilder, UserMessageBuilder},
     },
     Client,
 };
@@ -9,13 +9,16 @@ use async_dashscope::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv()?;
+    // let s = UserMessageBuilder::default().content("请将这句话翻译成英文：你好，世界！").build()?.into();
     let request = GenerationParamBuilder::default()
         .model("qwen-turbo".to_string())
         .input(
             InputBuilder::default()
                 .messages(vec![
                     MessageBuilder::default().role("system").content("你是一个出色的翻译专家").build()?,
-                    MessageBuilder::default().user().content("请将这句话翻译成英文：你好，世界！").build()?,
+                    // MessageBuilder::default().user().content("请将这句话翻译成英文：你好，世界！").build()?, 
+                    // 和上面等效
+                    UserMessageBuilder::default().content("请将这句话翻译成英文：你好，世界！").build()?.into(),
                 ])
                 .build()?,
         )

--- a/examples/roles.rs
+++ b/examples/roles.rs
@@ -1,0 +1,34 @@
+use async_dashscope::{
+    operation::{
+        common::ParametersBuilder,
+        generation::{GenerationParamBuilder, InputBuilder, MessageBuilder},
+    },
+    Client,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv()?;
+    let request = GenerationParamBuilder::default()
+        .model("qwen-turbo".to_string())
+        .input(
+            InputBuilder::default()
+                .messages(vec![
+                    MessageBuilder::default().role("system").content("你是一个出色的翻译专家").build()?,
+                    MessageBuilder::default().user().content("请将这句话翻译成英文：你好，世界！").build()?,
+                ])
+                .build()?,
+        )
+        .parameters(
+            ParametersBuilder::default()
+                .result_format("message")
+                .build()?,
+        )
+        .build()?;
+
+    let client = Client::default();
+
+    let response = client.generation().call(request).await?;
+    dbg!(response);
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@
 // https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation  - 语音合成
 // https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis - 创意海报生成API参考
 
+// todo: Qwen3-Coder 暂不支持 dashscope 的基于 Partial Mode 的代码补全功能
+
 use derive_builder::Builder;
 use reqwest::header::AUTHORIZATION;
 use secrecy::{ExposeSecret as _, SecretString};

--- a/src/operation/common.rs
+++ b/src/operation/common.rs
@@ -6,9 +6,12 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
 pub struct Parameters {
+    /// 返回数据的格式。推荐优先设置为"message"
     #[builder(setter(into, strip_option))]
     #[builder(default=None)]
     pub result_format: Option<String>,
+
+    /// 当您使用翻译模型时需要配置的翻译参数。
     #[builder(setter(strip_option))]
     #[builder(default=None)]
     pub translation_options: Option<TranslationOptions>,
@@ -26,6 +29,7 @@ pub struct Parameters {
     // function call
     pub tools: Option<Vec<FunctionCall>>,
 
+    /// 是否开启并行工具调用。参数为true时开启，为false时不开启。并行工具调用详情请参见：[并行工具调用](https://help.aliyun.com/zh/model-studio/qwen-function-calling#cb6b5c484bt4x)。
     #[builder(setter(into, strip_option))]
     #[builder(default=None)]
     pub parallel_tool_calls: Option<bool>,
@@ -42,11 +46,12 @@ pub struct Parameters {
     #[builder(default=None)]
     pub enable_search: Option<bool>,
 
+    /// 联网搜索的策略。仅当enable_search为true时生效。
     #[builder(setter(into, strip_option))]
     #[builder(default=None)]
     pub search_options: Option<SearchOptions>,
 
-    // 只支持 qwen3, 对 QwQ 与 DeepSeek-R1 模型无效。
+    /// 只支持 qwen3, 对 QwQ 与 DeepSeek-R1 模型无效。
     #[builder(setter(into, strip_option))]
     #[builder(default=None)]
     pub enable_thinking: Option<bool>,
@@ -54,6 +59,32 @@ pub struct Parameters {
     #[builder(setter(into, strip_option))]
     #[builder(default=None)]
     pub response_format: Option<ResponseFormat>,
+
+    /// 模型生成时连续序列中的重复度。提高repetition_penalty时可以降低模型生成的重复度，1.0表示不做惩罚。没有严格的取值范围，只要大于0即可。
+    #[builder(setter(into, strip_option))]
+    #[builder(default=None)]
+    repetition_penalty: Option<f64>,
+
+    /// 控制模型生成文本时的内容重复度。
+    /// 
+    /// 取值范围：[-2.0, 2.0]。正数会减少重复度，负数会增加重复度。
+    /// 
+    /// 适用场景：
+    /// - 较高的presence_penalty适用于要求多样性、趣味性或创造性的场景，如创意写作或头脑风暴。
+    /// - 较低的presence_penalty适用于要求一致性或专业术语的场景，如技术文档或其他正式文档。
+    #[builder(setter(into, strip_option))]
+    #[builder(default=None)]
+    presence_penalty: Option<f64>,
+
+    /// 是否提高输入图片的默认Token上限。输入图片的默认Token上限为1280，配置为true时输入图片的Token上限为16384。
+    #[builder(setter(into, strip_option))]
+    #[builder(default=None)]
+    vl_high_resolution_images: Option<bool>,
+
+    /// 是否返回图像缩放后的尺寸。模型会对输入的图像进行缩放处理，配置为 True 时会返回图像缩放后的高度和宽度，开启流式输出时，该信息在最后一个数据块（chunk）中返回。支持Qwen-VL模型。
+    #[builder(setter(into, strip_option))]
+    #[builder(default=None)]
+    vl_enable_image_hw_output: Option<bool>,
 }
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]

--- a/src/operation/embeddings.rs
+++ b/src/operation/embeddings.rs
@@ -33,8 +33,10 @@ impl<'a> Embeddings<'a> {
     /// 如果操作失败，返回一个错误类型，便于错误处理和调试
     pub async fn call(&self, request: param::EmbeddingsParam) -> Result<output::EmbeddingsOutput> {
         // Validate parameters before making the request.
-        let validator = check_model_parameters(&request.model);
-        validator.validate(&request)?;
+        let validators = check_model_parameters(&request.model);
+        for valid in validators {
+            valid.validate(&request)?;
+        }
 
         // 发送POST请求到指定的服务端点，并传递请求参数
         // 该行代码是异步执行的，允许在等待网络操作时继续执行其他任务，提高程序效率

--- a/src/operation/generation.rs
+++ b/src/operation/generation.rs
@@ -1,7 +1,10 @@
 use crate::{client::Client, error::DashScopeError};
 use crate::{error::Result, operation::validate::check_model_parameters};
 pub use output::*;
-pub use param::{GenerationParam, GenerationParamBuilder, InputBuilder, MessageBuilder};
+pub use param::{
+    AssistantMessageBuilder, GenerationParam, GenerationParamBuilder, InputBuilder, MessageBuilder,
+    SystemMessageBuilder, ToolMessageBuilder, UserMessageBuilder,
+};
 
 mod output;
 mod param;

--- a/src/operation/generation.rs
+++ b/src/operation/generation.rs
@@ -39,8 +39,10 @@ impl<'a> Generation<'a> {
         }
 
         // 检查参数
-        let c = check_model_parameters(&request.model);
-        c.validate(&request)?;
+        let validators = check_model_parameters(&request.model);
+        for valid in validators {
+            valid.validate(&request)?;
+        }
 
         // 发送POST请求到生成服务，并等待结果
         self.client.post(GENERATION_PATH, request).await
@@ -80,8 +82,10 @@ impl<'a> Generation<'a> {
         request.stream = Some(true);
 
         // 检查参数（保持与 call 方法的一致性）
-        let c = check_model_parameters(&request.model);
-        c.validate(&request)?;
+        let validators = check_model_parameters(&request.model);
+        for valid in validators {
+            valid.validate(&request)?;
+        }
 
         // 通过客户端发起 POST 请求，使用修改后的 `request` 对象，并等待异步响应
         self.client.post_stream(GENERATION_PATH, request).await

--- a/src/operation/generation/param.rs
+++ b/src/operation/generation/param.rs
@@ -144,25 +144,37 @@ impl MessageBuilder {
 /// 模型的目标或角色。如果设置系统消息，请放在messages列表的第一位。
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
 pub struct SystemMessage {
-    #[builder(setter(into))]
+    #[builder(setter(into), default = "\"system\".to_string()")]
     pub role: String,
     #[builder(setter(into))]
     pub content: String,
+}
+
+impl From<SystemMessage> for Message {
+    fn from(value: SystemMessage) -> Self {
+        Self::System(value)
+    }
 }
 
 /// 用户发送给模型的消息
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
 pub struct UserMessage {
-    #[builder(setter(into))]
+    #[builder(setter(into), default = "\"user\".to_string()")]
     pub role: String,
     #[builder(setter(into))]
     pub content: String,
 }
 
+impl From<UserMessage> for Message {
+    fn from(value: UserMessage) -> Self {
+        Self::User(value)
+    }
+}
+
 /// 模型对用户消息的回复
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
 pub struct AssistantMessage {
-    #[builder(setter(into))]
+    #[builder(setter(into), default = "\"assistant\".to_string()")]
     pub role: String,
     #[builder(setter(into))]
     pub content: String,
@@ -175,6 +187,12 @@ pub struct AssistantMessage {
     /// 在发起 Function Calling后，模型回复的要调用的工具和调用工具时需要的参数。包含一个或多个对象。由上一轮模型响应的tool_calls字段获得。
     #[builder(setter(into, strip_option))]
     pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+impl From<AssistantMessage> for Message {
+    fn from(value: AssistantMessage) -> Self {
+        Self::Assistant(value)
+    }
 }
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
@@ -206,12 +224,18 @@ pub struct Function {
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, PartialEq)]
 pub struct ToolMessage {
-    #[builder(setter(into))]
+    #[builder(setter(into), default = "\"tool\".to_string()")]
     pub role: String,
     #[builder(setter(into))]
     pub content: String,
     #[builder(setter(into))]
     pub tool_call_id: Option<String>,
+}
+
+impl From<ToolMessage> for Message {
+    fn from(value: ToolMessage) -> Self {
+        Self::Tool(value)
+    }
 }
 
 impl RequestTrait for GenerationParam {

--- a/src/operation/multi_modal_conversation.rs
+++ b/src/operation/multi_modal_conversation.rs
@@ -43,8 +43,10 @@ impl<'a> MultiModalConversation<'a> {
         }
 
         // Validate parameters before making the request.
-        let validator = check_model_parameters(&request.model);
-        validator.validate(&request)?;
+        let validators = check_model_parameters(&request.model);
+        for valid in validators {
+            valid.validate(&request)?;
+        }
 
         let request = request
             .upload_file_to_oss(self.client.config().api_key().expose_secret())
@@ -84,8 +86,10 @@ impl<'a> MultiModalConversation<'a> {
         request.stream = Some(true);
 
         // Validate parameters before making the request.
-        let validator = check_model_parameters(&request.model);
-        validator.validate(&request)?;
+        let validators = check_model_parameters(&request.model);
+        for valid in validators {
+            valid.validate(&request)?;
+        }
 
         // 发起流式请求并返回结果流
         self.client


### PR DESCRIPTION
- 将 Message 类型重构为枚举类型，支持 system、user、assistant 和 tool 四种角色
- 添加对应的 Builder 类型和构建方法，优化消息构建过程
- 增加错误处理，确保消息角色的有效性
- 调整 Cargo.toml 中的依赖版本：
  - serde_json 升级到 1.0.141
  - tokio 升级到 1.47.0
  - reqwest 保持不变